### PR TITLE
MNIST download fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ clearly need to fix this
 
 To train on MNIST
 
-` python3 train.py --dataset mnist --batch_size 50 --dim 32 -- output_size 784`
+`python3 train.py --dataset mnist --batch_size 50 --dim 32 -o 784`
 
 To train on CIFAR10
 
-` python3 train.py --dataset cifar10 --batch_size 64 --dim 32 -- output_size 3072`
+`python3 train.py --dataset cifar10 --batch_size 64 --dim 32 -o 3072`
 
 ### Acknowledgements
 

--- a/data/mnist.py
+++ b/data/mnist.py
@@ -1,6 +1,6 @@
 import os
 import gzip
-import urllib
+import urllib.request
 import numpy as np
 import _pickle as pickle
 
@@ -54,7 +54,7 @@ def load(batch_size, test_batch_size, n_labelled=None):
 
     if not os.path.isfile(filepath):
         print ("Couldn't find MNIST dataset in "+filepath+", downloading...")
-        urllib.urlretrieve(url, filepath)
+        urllib.request.urlretrieve(url, filepath)
 
     with gzip.open(filepath, 'rb') as f:
         train_data, dev_data, test_data = pickle.load(f, encoding='iso-8859-1')

--- a/plot.py
+++ b/plot.py
@@ -1,4 +1,6 @@
 import numpy as np
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import collections
 import time

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+torch
+torchvision
+matplotlib
+numpy
+scipy

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+pip install -r requirements.txt
+python3 train.py --dataset mnist --batch_size 50 --dim 32 --o 784


### PR DESCRIPTION
The `urllib` change and the `images/mnist` dummy directory are necessary for MNIST to download properly under python 3. Adding `requirements.txt` and `start.sh` is just for convenience. The matplotlib `Agg` thing allows output of the plots while running the experiment in a nongraphical environment (eg. SSH).
